### PR TITLE
fix(app): Handle breaking  entries in relative path to the resource

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -1,6 +1,7 @@
 'use strict';
 var path = require('path');
 var NGUX_EXTENSION = '.ngux';
+var EXTERNAL_UX_DIR = 'external-ux';
 
 /**
  * Helper module for NguxLoader
@@ -71,6 +72,15 @@ var getPaths = function(pathsConfig) {
 
     var resdir = path.dirname(resourcePath);
     var resdirRelative = path.relative(context, resdir);
+    if (/^(\.\.[\\\/])+/.test(resdirRelative)) {
+        // Put outputs of .ngux files in other modules in an `external-ux` folder
+        resdirRelative = resdirRelative.replace(/^(\.\.?[\\\/])*/, EXTERNAL_UX_DIR);
+    }
+
+    // We shouldn't hit other `..`s in the path, but just in case remove them.
+    if (resdirRelative.indexOf('..') >= 0) {
+        resdirRelative = resdirRelative.replace(/../, '');
+    }
 
     var htmlName = resName + '.html';
     var jsName = resName + '.js';

--- a/test/fixture/expectations/comments1.g.ux
+++ b/test/fixture/expectations/comments1.g.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="NGUXApp" Background="{var0}">
     <StackPanel Items="{children0}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
 </Panel>

--- a/test/fixture/expectations/component.in.g.ux
+++ b/test/fixture/expectations/component.in.g.ux
@@ -1,3 +1,3 @@
 <Panel Items="{children0}" MatchKey="type" ux:Class="MyApp">
-    <MissionCard ux:Case="MyApp_Scope1" />
+    <MissionCard ux:Template="MyApp_Scope1" />
 </Panel>

--- a/test/fixture/expectations/mutliplerectangles.g.ux
+++ b/test/fixture/expectations/mutliplerectangles.g.ux
@@ -1,7 +1,7 @@
 <Panel ux:Class="NGUXApp" Background="{var0}">
     <StackPanel Items="{children0}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
-        <Rectangle ux:Case="NGUXApp_Scope2" Fill="Red" Height="30" Margin="10" />
-        <NGUXChild ux:Case="NGUXApp_Scope3" />
+        <Rectangle ux:Template="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope2" Fill="Red" Height="30" Margin="10" />
+        <NGUXChild ux:Template="NGUXApp_Scope3" />
     </StackPanel>
 </Panel>

--- a/test/fixture/expectations/spaces1.g.ux
+++ b/test/fixture/expectations/spaces1.g.ux
@@ -1,14 +1,14 @@
 <Panel ux:Class="NGUXApp" Background="{var0}">
     <StackPanel Items="{children0}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
     <StackPanel Items="{children1}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope2" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope2" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
     <StackPanel Items="{children2}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope3" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope3" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
     <StackPanel Items="{children3}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope4" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope4" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
 </Panel>

--- a/test/fixture/expectations/spaces2.g.ux
+++ b/test/fixture/expectations/spaces2.g.ux
@@ -1,5 +1,5 @@
 <Panel ux:Class="NGUXApp" Background="{var0}">
     <StackPanel Items="{children0}" MatchKey="type">
-        <Rectangle ux:Case="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
+        <Rectangle ux:Template="NGUXApp_Scope1" Fill="Red" Height="30" Margin="10" />
     </StackPanel>
 </Panel>


### PR DESCRIPTION
Previously, the loader was placing the outputs of `.ngux` files in directories next to the dev or prod folders because the relative path to the resource was naïvely used relative to the outputRoot. Now, if the relative resource path begins with a `..` (which implies the next path component is the module name, in a [`generator-mcfly-ng2`](https://github.com/mcfly-io/generator-mcfly-ng2) project) the `..` will be replaced with `external-ux`, placing the files in a separate dir, but still inside the correct dist folder. Subsequent `..`s are discarded.